### PR TITLE
Allow the videoSource array to contain strings again

### DIFF
--- a/script/jquery.videobackground.js
+++ b/script/jquery.videobackground.js
@@ -179,10 +179,11 @@
 						 *
 						 */
 						$.each(that.settings.videoSource, function () {
-							if (this[1] !== undefined) {
+							var isArray = Object.prototype.toString.call(this) === '[object Array]';
+							if (isArray && this[1] !== undefined) {
 								compiledSource = compiledSource + '<source src="' + this[0] + '" type="' + this[1] + '">';
 							} else {
-								compiledSource = compiledSource + '<source src="' + this[0] + '">';
+								compiledSource = compiledSource + '<source src="' + (isArray ? this[0] : this) + '">';
 							}
 						});
 						attributes = attributes + 'preload="' + that.settings.preload + '"';


### PR DESCRIPTION
As of 613967a8 elements in the `videoSource` array have to be arrays with one or two items, leading to awkward syntax when no type is provided:

``` javascript
    videoSource: [
        ['http://....'],
        ['http://....']
    ]
```

instead of this:

``` javascript
    videoSource: [
        'http://....',
        'http://....'
    ]
```

Since you're still using the old syntax on http://www.georgepaterson.com/sandbox/jquery-html5-video-background-demo/ I'm assuming that's a bug, and I've attached a fix that allows both syntaxes.
