### PR TITLE
Add configuration parameter to start video muted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Plugin parameters:
 *	preloadCallback: Allows a function to be triggered when the video preload is initiated.
 *	loadedCallback: Allows a function to be triggered when the video is loaded.
 *	resizeTo: Allows the video background to resize to either the document or the window. Default is document.
+*	muted: Starts video muted.  Default is falsey.
 
 Video trailer from [http://www.bigbuckbunny.org/](www.bigbuckbunny.org), an open source [http://www.blender.org/](Blender) project.
 

--- a/script/jquery.videobackground.js
+++ b/script/jquery.videobackground.js
@@ -201,6 +201,9 @@
 						if (that.settings.loop) {
 							attributes = attributes + ' loop="loop"';
 						}
+						if (that.settings.muted) {
+							attributes = attributes + ' muted="muted"';
+						}
 						$(that).html('<video ' + attributes + '>' + compiledSource + '</video>');
 						/*
 						 * Append the control box either to the supplied that or the video background that.	

--- a/tests/video.js
+++ b/tests/video.js
@@ -32,6 +32,16 @@ $(document).ready(function () {
 		}).remove();
 		ok(true, '.videobackground() as an array of arrays called on empty collection');
 	});
+	test('config', function() {
+		var $div, $vid;
+		$div = $('<div></div>').appendTo('body').videobackground({
+			videoSource: videoFiles,
+			muted: true,
+		});
+		$vid = $div.find('video');
+		ok($vid.attr('muted')=='muted', '.videobackground() "muted" configuration paramter works');
+		$div.remove();
+	});
 	test('play', function () {
 		$('<div></div>').appendTo('body').videobackground({
 			videoSource: videoFiles


### PR DESCRIPTION
We're using this plugin for a website redesign, but we need the video to start muted.  I tried calling the `mute` method, but couldn't make it work reliably (sound would start playing when a looped video starts replaying).  This appends `mute="muted"` to the `<video>` tag on creation.  Tests & documentation updated.
